### PR TITLE
release: Sprint 5 — Dark/Light Mode (v1.8.0)

### DIFF
--- a/Tests/MultiDialog4FMX.Tests.Builder.pas
+++ b/Tests/MultiDialog4FMX.Tests.Builder.pas
@@ -90,6 +90,12 @@ type
 
     [Test]
     procedure TestSetAnimation_DefaultIsNone;
+
+    [Test]
+    procedure TestSetTheme_StoresValue;
+
+    [Test]
+    procedure TestSetTheme_DefaultIsAuto;
   end;
 
 implementation
@@ -275,6 +281,19 @@ procedure TDialogBuilderTests.TestSetAnimation_DefaultIsNone;
 begin
   Assert.AreEqual(TDialogAnimation.danNone, FDialog.Animation,
     'Animação padrão deve ser danNone');
+end;
+
+procedure TDialogBuilderTests.TestSetTheme_StoresValue;
+begin
+  FDialog.SetTheme(TDialogTheme.dthDark);
+  Assert.AreEqual(TDialogTheme.dthDark, FDialog.Theme,
+    'SetTheme(dthDark) deve armazenar dthDark em FTheme');
+end;
+
+procedure TDialogBuilderTests.TestSetTheme_DefaultIsAuto;
+begin
+  Assert.AreEqual(TDialogTheme.dthAuto, FDialog.Theme,
+    'Tema padrão deve ser dthAuto após Create');
 end;
 
 initialization

--- a/Tests/MultiDialog4FMX.Tests.Mocks.pas
+++ b/Tests/MultiDialog4FMX.Tests.Mocks.pas
@@ -59,6 +59,7 @@ type
     property CustomIconColor: TAlphaColor read FCustomIconColor;
     property ResultCallback: TDialogResultProc read FResultCallback;
     property Animation: TDialogAnimation read FAnimation;
+    property Theme: TDialogTheme read FTheme;
   end;
 
 implementation

--- a/src/MultiDialog4FMX.Base.pas
+++ b/src/MultiDialog4FMX.Base.pas
@@ -59,6 +59,7 @@ type
     FFontSize: Single;
     FBorderRadius: Single;
     FAnimation: TDialogAnimation;
+    FTheme: TDialogTheme;
     FCustomSVG: string;
     FCustomIconColor: TAlphaColor;
     FResultCallback: TDialogResultProc;
@@ -77,6 +78,7 @@ type
     function SetFontSize(const ASize: Single): IDialogBuilder;
     function SetBorderRadius(const ARadius: Single): IDialogBuilder;
     function SetAnimation(const AAnimation: TDialogAnimation): IDialogBuilder;
+    function SetTheme(const ATheme: TDialogTheme): IDialogBuilder;
     function SetIcon(const ASVG: string): IDialogBuilder;
     function SetIconColor(const AColor: TAlphaColor): IDialogBuilder;
     function SetOnResult(const ACallback: TDialogResultProc): IDialogBuilder;
@@ -183,6 +185,12 @@ end;
 function TDialogBase.SetAnimation(const AAnimation: TDialogAnimation): IDialogBuilder;
 begin
   FAnimation := AAnimation;
+  Result := Self;
+end;
+
+function TDialogBase.SetTheme(const ATheme: TDialogTheme): IDialogBuilder;
+begin
+  FTheme := ATheme;
   Result := Self;
 end;
 

--- a/src/MultiDialog4FMX.FMX.pas
+++ b/src/MultiDialog4FMX.FMX.pas
@@ -32,6 +32,7 @@ type
     FTimeoutOrigText  : string;
     FTimeoutRemaining : Integer;
     FTimeoutCancelled : Boolean;
+    function  ResolveIsDark: Boolean;
     procedure ApplyEntranceAnimation(const AOverlay: TLayout;
                                      const ADialogRect: TRectangle);
     procedure ApplyExitAnimation(const AOverlay: TLayout;
@@ -88,6 +89,23 @@ const
   C_BaseTitleFontSize   = 16;
 
 { TFMXDialog }
+
+function TFMXDialog.ResolveIsDark: Boolean;
+var
+  LSvc: IFMXSystemAppearanceService;
+begin
+  case FTheme of
+    dthDark:  Result := True;
+    dthLight: Result := False;
+  else
+    // dthAuto: query the platform; fall back to Light if service unavailable
+    if TPlatformServices.Current.SupportsPlatformService(
+         IFMXSystemAppearanceService, LSvc) then
+      Result := LSvc.ThemeKind = TSystemThemeKind.Dark
+    else
+      Result := False;
+  end;
+end;
 
 function TFMXDialog.GetPlatformScale: Single;
 var
@@ -162,7 +180,7 @@ begin
   LBgRect.Parent := LOverlay;
   LBgRect.Align := TAlignLayout.Contents;
   LBgRect.Fill.Color := TAlphaColorRec.Black;
-  LBgRect.Opacity := 0.4;
+  LBgRect.Opacity := IfThen(ResolveIsDark, 0.65, 0.40);
   LBgRect.Stroke.Kind := TBrushKind.None;
 
   ABgRect := LBgRect;
@@ -179,8 +197,18 @@ begin
   LDialogRect.Width := C_BaseDialogWidth;
   LDialogRect.XRadius := FBorderRadius;
   LDialogRect.YRadius := FBorderRadius;
-  LDialogRect.Fill.Color := TAlphaColorRec.White;
-  LDialogRect.Stroke.Kind := TBrushKind.None;
+  if ResolveIsDark then
+  begin
+    LDialogRect.Fill.Color   := $FF2D2D2D;
+    LDialogRect.Stroke.Kind  := TBrushKind.Solid;
+    LDialogRect.Stroke.Color := $FF444444;
+  end
+  else
+  begin
+    LDialogRect.Fill.Color   := TAlphaColorRec.White;
+    LDialogRect.Stroke.Kind  := TBrushKind.Solid;
+    LDialogRect.Stroke.Color := $FFE0E0E0;
+  end;
   LDialogRect.Padding.Rect := RectF(4, 4, 4, 4);
   FDialogRect := LDialogRect;
   Result := LDialogRect;
@@ -201,7 +229,13 @@ begin
   LLblTitle.Margins.Rect := RectF(16, 12, 16, 4);
   LLblTitle.Height := C_BaseTitleHeight;
   LLblTitle.TextSettings.Font.Size := C_BaseTitleFontSize;
-  LLblTitle.StyledSettings := [TStyledSetting.Style, TStyledSetting.FontColor];
+  if ResolveIsDark then
+  begin
+    LLblTitle.StyledSettings := [TStyledSetting.Style];
+    LLblTitle.TextSettings.FontColor := TAlphaColorRec.White;
+  end
+  else
+    LLblTitle.StyledSettings := [TStyledSetting.Style, TStyledSetting.FontColor];
   LLblTitle.VertTextAlign := TTextAlign.Center;
 end;
 
@@ -280,7 +314,13 @@ begin
     LblMsg.Text := FMessage;
     LblMsg.VertTextAlign := TTextAlign.Leading;
     LblMsg.TextSettings.Font.Size := FFontSize;
-    LblMsg.StyledSettings := [TStyledSetting.Style, TStyledSetting.FontColor];
+    if ResolveIsDark then
+    begin
+      LblMsg.StyledSettings := [TStyledSetting.Style];
+      LblMsg.TextSettings.FontColor := TAlphaColorRec.White;
+    end
+    else
+      LblMsg.StyledSettings := [TStyledSetting.Style, TStyledSetting.FontColor];
   end;
 
   if AIconPresent then
@@ -313,10 +353,11 @@ var
   LRec          : TButtonHandler;
   LBtn          : TButton;
   LColorRect    : TRectangle;
-  LIsResponsive : Boolean;
-  LMarginRight  : Integer;
-  LMarginTop    : Integer;
-  I             : Integer;
+  LIsResponsive   : Boolean;
+  LMarginRight    : Integer;
+  LMarginTop      : Integer;
+  LEffectiveColor : TAlphaColor;
+  I               : Integer;
 begin
   LBtnLayout := TFlowLayout.Create(ADialogRect);
   LBtnLayout.Parent := ADialogRect;
@@ -375,7 +416,11 @@ begin
 
     LRec.Overlay := AOverlay;
 
-    if LRec.Color <> TAlphaColor(0) then
+    LEffectiveColor := LRec.Color;
+    if ResolveIsDark and (LEffectiveColor = TAlphaColor(0)) then
+      LEffectiveColor := $FF555555;  // neutral dark-grey for uncoloured buttons in dark mode
+
+    if LEffectiveColor <> TAlphaColor(0) then
     begin
       // Colored button: canvas-painted TRectangle — avoids Android TLabel/TBrush
       // rendering issue where all buttons inherit the last button's text and color.
@@ -391,7 +436,7 @@ begin
       LColorRect.Margins.Right := LMarginRight;
       LColorRect.Margins.Top   := LMarginTop;
 
-      LColorRect.Tag        := NativeInt(LRec.Color);  // per-instance color for paint handler
+      LColorRect.Tag        := NativeInt(LEffectiveColor);  // per-instance color for paint handler
       LColorRect.TagString  := LRec.Text;              // per-instance text for paint handler
       LColorRect.OnPainting := PaintColoredBtn;        // self-contained paint
 

--- a/src/MultiDialog4FMX.Interfaces.pas
+++ b/src/MultiDialog4FMX.Interfaces.pas
@@ -13,6 +13,7 @@ uses
 type
   TMultiDialogType = (mdtCustom, mdtWarning, mdtError, mdtInformation, mdtConfirmation, mdtQuestion);
   TDialogAnimation = (danNone, danFade, danScale, danSlide);
+  TDialogTheme     = (dthAuto, dthLight, dthDark);
   TDialogResultProc = reference to procedure(const AResult: TModalResult);
 
   IDialogButtonsBuilder = interface;
@@ -56,6 +57,11 @@ type
     /// Define a animação de entrada/saída.
     /// </summary>
     function SetAnimation(const AAnimation: TDialogAnimation): IDialogBuilder;
+
+    /// <summary>
+    /// Define o tema de cores do diálogo (claro, escuro ou automático pelo sistema).
+    /// </summary>
+    function SetTheme(const ATheme: TDialogTheme): IDialogBuilder;
 
     /// <summary>
     /// Define um SVG customizado para o ícone do diálogo.


### PR DESCRIPTION
## Summary

- Squash merge from `feature/sprint5-dark-light-mode` via `develop`
- Implements R22: `SetTheme(TDialogTheme)` — suporte a Dark/Light/System mode
- Fix: botões sem cor legíveis em dark mode

## Changes

- `src/MultiDialog4FMX.FMX.pas` — SetTheme + TDialogTheme + correção de contraste

## Test plan

- [ ] Light mode: dialog visual correto
- [ ] Dark mode: dialog visual correto, botões legíveis
- [ ] System mode: detecta tema do dispositivo automaticamente
- [ ] Regressão: todos os tipos de dialog funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)