### PR TITLE
fix(compat): SVG_QUESTION com numeros colados quebra o parser do FMX

### DIFF
--- a/src/MultiDialog4FMX.FMX.pas
+++ b/src/MultiDialog4FMX.FMX.pas
@@ -76,8 +76,13 @@ const
   // Literal quebrado em pedacos <=255 chars: Delphi <=11 limita literais de string a 255
   // elementos (E2056); o Delphi 12 removeu o limite. A concatenacao sofre constant folding,
   // entao o valor final e identico em todas as versoes (sem guarda condicional necessaria).
+  // Numeros separados por espaco (ex. "-.9 .92" em vez de "-.9.92"): dois numeros com ponto
+  // decimal colados sem separador (so a troca de sinal/segundo ponto marca a fronteira) faz
+  // o parser de TPathData falhar com EConvertError ("X is not a valid floating point value"),
+  // abortando InternalShow antes de CalculateFinalHeight rodar (dialogo fica sem altura,
+  // botoes "flutuam" fora da caixa). Espaco extra e um separador SVG valido, geometria identica.
   SVG_QUESTION = 'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2z' +
-                 'm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z';
+                 'm2.07-7.75l-.9 .92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1 .45-2.1 1.17-2.83l1.24-1.26c.37-.36 .59-.86 .59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z';
   SVG_SUCCESS  = 'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z';
 
   // Base layout constants (logical points; multiply by Screen.Scale for DPI-aware size).
@@ -295,16 +300,25 @@ begin
     LIconPath.Stroke.Kind := TBrushKind.None;
 
     // --- SVG ---
-    if FCustomSVG <> '' then
-      LIconPath.Data.Data := FCustomSVG
-    else
-      case FMsgType of
-        mdtWarning:      LIconPath.Data.Data := SVG_WARNING;
-        mdtError:        LIconPath.Data.Data := SVG_ERROR;
-        mdtInformation:  LIconPath.Data.Data := SVG_INFO;
-        mdtQuestion:     LIconPath.Data.Data := SVG_QUESTION;
-        mdtConfirmation: LIconPath.Data.Data := SVG_SUCCESS;
-      end;
+    // Um path SVG malformado (customizado via SetCustomIcon, ou um builtin futuro) nao pode
+    // abortar a montagem do dialogo: CalculateFinalHeight (mais abaixo em InternalShow) so
+    // roda se este metodo completar. Sem o guard, uma excecao aqui deixa o LDialogRect sem
+    // altura definida e os botoes (montados antes, em BuildButtons) "flutuam" fora da caixa.
+    try
+      if FCustomSVG <> '' then
+        LIconPath.Data.Data := FCustomSVG
+      else
+        case FMsgType of
+          mdtWarning:      LIconPath.Data.Data := SVG_WARNING;
+          mdtError:        LIconPath.Data.Data := SVG_ERROR;
+          mdtInformation:  LIconPath.Data.Data := SVG_INFO;
+          mdtQuestion:     LIconPath.Data.Data := SVG_QUESTION;
+          mdtConfirmation: LIconPath.Data.Data := SVG_SUCCESS;
+        end;
+    except
+      // Degrada para "sem icone" (container 40x40 permanece, so o path fica vazio) em vez
+      // de propagar e interromper InternalShow no meio da montagem.
+    end;
 
     // --- Cor ---
     if FCustomIconColor <> TAlphaColor(0) then


### PR DESCRIPTION
## O que corrige

Descoberto ao validar a v1.9.1 em campo (projeto de cliente real, usando `mdtQuestion` como tipo de diálogo): o path SVG do ícone `mdtQuestion` tem 4 ocorrências de dois números decimais colados sem separador (ex. `-.9.92`, onde a fronteira só é marcada pelo segundo ponto decimal). O parser de `TPathData` do FMX falha nesse padrão, lançando `EConvertError` (`'X' is not a valid floating point value`) ao atribuir `LIconPath.Data.Data`.

Como isso acontece dentro de `BuildBody` — chamado **antes** de `CalculateFinalHeight` definir a altura do diálogo — a exceção aborta `InternalShow` no meio da montagem: o `LDialogRect` fica sem altura definida enquanto os botões (montados antes, em `BuildButtons`) mantêm seu tamanho normal, produzindo a aparência de caixa desconfigurada com botões flutuando fora dela, e a exceção não tratada aparece como uma messagebox genérica de erro.

**Reproduziu num sample próprio do repositório, sem nenhuma dependência externa** — não é um bug de compatibilidade Delphi ≤11 nem específico de nenhum projeto cliente; é um caso não coberto do path do ícone de pergunta, presente desde que esse SVG foi escrito.

## Correção

- `SVG_QUESTION`: inserido espaço separador nas 4 ocorrências do padrão perigoso. Confirmado programaticamente que a string sem os espaços inseridos é idêntica byte a byte à original — nenhum dígito mudou, só a tokenização ficou inequívoca. As outras 4 constantes SVG (`WARNING`, `ERROR`, `INFO`, `SUCCESS`) não têm esse padrão.
- `BuildBody`: guarda `try..except` em torno da atribuição do path SVG — qualquer path malformado (builtin ou via `SetCustomIcon`) degrada para "sem ícone" em vez de abortar a montagem do diálogo. Proteção contra a mesma classe de falha no futuro, para qualquer SVG, não só este caso.

## Validação
- Build limpo (Win32/Debug) — BUILD OK, sem erros/warnings.
- Teste manual do usuário com `mdtQuestion` — confirmado corrigido.

## Test plan
- [x] BUILD OK
- [x] Teste manual `mdtQuestion` — aprovado pelo usuário

🤖 Gerado com [Claude Code](https://claude.com/claude-code)